### PR TITLE
Add the new sample for datachannels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-mdn-samples
-===========
+samples-server
+==============
 
 This is a live sample server for MDN, which I hope we will be able to use to host content that only works when on a less restrictive environment than running in an iframe on Kuma.
 
 The ''s'' directory contains a folder for each project that needs to be available. Each one has a manifest and whatever files that service requires.
+
+The ''v'' directory is a place we can keep miscellaneous assets which may be needed by MDN content, can't be attached to MDN pages, and have no other home.

--- a/s/adapter.js
+++ b/s/adapter.js
@@ -1,0 +1,379 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+/* More information about these options at jshint.com/docs/options */
+/* jshint browser: true, camelcase: true, curly: true, devel: true,
+   eqeqeq: true, forin: false, globalstrict: true, node: true,
+   quotmark: single, undef: true, unused: strict */
+/* global mozRTCIceCandidate, mozRTCPeerConnection, Promise,
+mozRTCSessionDescription, webkitRTCPeerConnection, MediaStreamTrack */
+/* exported trace,requestUserMedia */
+
+'use strict';
+
+var getUserMedia = null;
+var attachMediaStream = null;
+var reattachMediaStream = null;
+var webrtcDetectedBrowser = null;
+var webrtcDetectedVersion = null;
+var webrtcMinimumVersion = null;
+
+function trace(text) {
+  // This function is used for logging.
+  if (text[text.length - 1] === '\n') {
+    text = text.substring(0, text.length - 1);
+  }
+  if (window.performance) {
+    var now = (window.performance.now() / 1000).toFixed(3);
+    console.log(now + ': ' + text);
+  } else {
+    console.log(text);
+  }
+}
+
+if (navigator.mozGetUserMedia) {
+  console.log('This appears to be Firefox');
+
+  webrtcDetectedBrowser = 'firefox';
+
+  // the detected firefox version.
+  webrtcDetectedVersion =
+    parseInt(navigator.userAgent.match(/Firefox\/([0-9]+)\./)[1], 10);
+
+  // the minimum firefox version still supported by adapter.
+  webrtcMinimumVersion = 31;
+
+  // The RTCPeerConnection object.
+  window.RTCPeerConnection = function(pcConfig, pcConstraints) {
+    if (webrtcDetectedVersion < 38) {
+      // .urls is not supported in FF < 38.
+      // create RTCIceServers with a single url.
+      if (pcConfig && pcConfig.iceServers) {
+        var newIceServers = [];
+        for (var i = 0; i < pcConfig.iceServers.length; i++) {
+          var server = pcConfig.iceServers[i];
+          if (server.hasOwnProperty('urls')) {
+            for (var j = 0; j < server.urls.length; j++) {
+              var newServer = {
+                url: server.urls[j]
+              };
+              if (server.urls[j].indexOf('turn') === 0) {
+                newServer.username = server.username;
+                newServer.credential = server.credential;
+              }
+              newIceServers.push(newServer);
+            }
+          } else {
+            newIceServers.push(pcConfig.iceServers[i]);
+          }
+        }
+        pcConfig.iceServers = newIceServers;
+      }
+    }
+    return new mozRTCPeerConnection(pcConfig, pcConstraints);
+  };
+
+  // The RTCSessionDescription object.
+  window.RTCSessionDescription = mozRTCSessionDescription;
+
+  // The RTCIceCandidate object.
+  window.RTCIceCandidate = mozRTCIceCandidate;
+
+  // getUserMedia constraints shim.
+  getUserMedia = (webrtcDetectedVersion < 38) ?
+      function(c, onSuccess, onError) {
+    var constraintsToFF37 = function(c) {
+      if (typeof c !== 'object' || c.require) {
+        return c;
+      }
+      var require = [];
+      Object.keys(c).forEach(function(key) {
+        var r = c[key] = (typeof c[key] === 'object') ?
+            c[key] : {ideal: c[key]};
+        if (r.exact !== undefined) {
+          r.min = r.max = r.exact;
+          delete r.exact;
+        }
+        if (r.min !== undefined || r.max !== undefined) {
+          require.push(key);
+        }
+        if (r.ideal !== undefined) {
+          c.advanced = c.advanced || [];
+          var oc = {};
+          oc[key] = {min: r.ideal, max: r.ideal};
+          c.advanced.push(oc);
+          delete r.ideal;
+          if (!Object.keys(r).length) {
+            delete c[key];
+          }
+        }
+      });
+      if (require.length) {
+        c.require = require;
+      }
+      return c;
+    };
+    console.log('spec: ' + JSON.stringify(c));
+    c.audio = constraintsToFF37(c.audio);
+    c.video = constraintsToFF37(c.video);
+    console.log('ff37: ' + JSON.stringify(c));
+    return navigator.mozGetUserMedia(c, onSuccess, onError);
+  } : navigator.mozGetUserMedia.bind(navigator);
+
+  navigator.getUserMedia = getUserMedia;
+
+  // Shim for mediaDevices on older versions.
+  if (!navigator.mediaDevices) {
+    navigator.mediaDevices = {getUserMedia: requestUserMedia,
+      addEventListener: function() { },
+      removeEventListener: function() { }
+    };
+  }
+  navigator.mediaDevices.enumerateDevices =
+      navigator.mediaDevices.enumerateDevices || function() {
+    return new Promise(function(resolve) {
+      var infos = [
+        {kind: 'audioinput', deviceId: 'default', label:'', groupId:''},
+        {kind: 'videoinput', deviceId: 'default', label:'', groupId:''}
+      ];
+      resolve(infos);
+    });
+  };
+
+  if (webrtcDetectedVersion < 41) {
+    // Work around http://bugzil.la/1169665
+    var orgEnumerateDevices =
+        navigator.mediaDevices.enumerateDevices.bind(navigator.mediaDevices);
+    navigator.mediaDevices.enumerateDevices = function() {
+      return orgEnumerateDevices().catch(function(e) {
+        if (e.name === 'NotFoundError') {
+          return [];
+        }
+        throw e;
+      });
+    };
+  }
+  // Attach a media stream to an element.
+  attachMediaStream = function(element, stream) {
+    console.log('Attaching media stream');
+    element.mozSrcObject = stream;
+  };
+
+  reattachMediaStream = function(to, from) {
+    console.log('Reattaching media stream');
+    to.mozSrcObject = from.mozSrcObject;
+  };
+
+} else if (navigator.webkitGetUserMedia) {
+  console.log('This appears to be Chrome');
+
+  webrtcDetectedBrowser = 'chrome';
+
+  // the detected chrome version.
+  webrtcDetectedVersion =
+    parseInt(navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./)[2], 10);
+
+  // the minimum chrome version still supported by adapter.
+  webrtcMinimumVersion = 38;
+
+  // The RTCPeerConnection object.
+  window.RTCPeerConnection = function(pcConfig, pcConstraints) {
+    return new webkitRTCPeerConnection(pcConfig, pcConstraints);
+  };
+  // add promise support
+  ['createOffer', 'createAnswer'].forEach(function(method) {
+    var nativeMethod = webkitRTCPeerConnection.prototype[method];
+    webkitRTCPeerConnection.prototype[method] = function() {
+      var self = this;
+      if (arguments.length < 1 || (arguments.length === 1 &&
+          typeof(arguments[0]) === 'object')) {
+        var opts = arguments.length === 1 ? arguments[0] : undefined;
+        return new Promise(function(resolve, reject) {
+          nativeMethod.apply(self, [resolve, reject, opts]);
+        });
+      } else {
+        return nativeMethod.apply(this, arguments);
+      }
+    };
+  });
+
+  ['setLocalDescription', 'setRemoteDescription',
+      'addIceCandidate'].forEach(function(method) {
+    var nativeMethod = webkitRTCPeerConnection.prototype[method];
+    webkitRTCPeerConnection.prototype[method] = function() {
+      var args = arguments;
+      var self = this;
+      return new Promise(function(resolve, reject) {
+        nativeMethod.apply(self, [args[0],
+            function() {
+              resolve();
+              if (args.length >= 2) {
+                args[1].apply(null, []);
+              }
+            },
+            function(err) {
+              reject(err);
+              if (args.length >= 3) {
+                args[2].apply(null, [err]);
+              }
+            }]
+          );
+      });
+    };
+  });
+
+  // getUserMedia constraints shim.
+  getUserMedia = function(c, onSuccess, onError) {
+    var constraintsToChrome = function(c) {
+      if (typeof c !== 'object' || c.mandatory || c.optional) {
+        return c;
+      }
+      var cc = {};
+      Object.keys(c).forEach(function(key) {
+        if (key === 'require' || key === 'advanced') {
+          return;
+        }
+        var r = (typeof c[key] === 'object') ? c[key] : {ideal: c[key]};
+        if (r.exact !== undefined && typeof r.exact === 'number') {
+          r.min = r.max = r.exact;
+        }
+        var oldname = function(prefix, name) {
+          if (prefix) {
+            return prefix + name.charAt(0).toUpperCase() + name.slice(1);
+          }
+          return (name === 'deviceId') ? 'sourceId' : name;
+        };
+        if (r.ideal !== undefined) {
+          cc.optional = cc.optional || [];
+          var oc = {};
+          if (typeof r.ideal === 'number') {
+            oc[oldname('min', key)] = r.ideal;
+            cc.optional.push(oc);
+            oc = {};
+            oc[oldname('max', key)] = r.ideal;
+            cc.optional.push(oc);
+          } else {
+            oc[oldname('', key)] = r.ideal;
+            cc.optional.push(oc);
+          }
+        }
+        if (r.exact !== undefined && typeof r.exact !== 'number') {
+          cc.mandatory = cc.mandatory || {};
+          cc.mandatory[oldname('', key)] = r.exact;
+        } else {
+          ['min', 'max'].forEach(function(mix) {
+            if (r[mix] !== undefined) {
+              cc.mandatory = cc.mandatory || {};
+              cc.mandatory[oldname(mix, key)] = r[mix];
+            }
+          });
+        }
+      });
+      if (c.advanced) {
+        cc.optional = (cc.optional || []).concat(c.advanced);
+      }
+      return cc;
+    };
+    console.log('spec:   ' + JSON.stringify(c)); // whitespace for alignment
+    c.audio = constraintsToChrome(c.audio);
+    c.video = constraintsToChrome(c.video);
+    console.log('chrome: ' + JSON.stringify(c));
+    return navigator.webkitGetUserMedia(c, onSuccess, onError);
+  };
+  navigator.getUserMedia = getUserMedia;
+
+  // Attach a media stream to an element.
+  attachMediaStream = function(element, stream) {
+    if (typeof element.srcObject !== 'undefined') {
+      element.srcObject = stream;
+    } else if (typeof element.src !== 'undefined') {
+      element.src = URL.createObjectURL(stream);
+    } else {
+      console.log('Error attaching stream to element.');
+    }
+  };
+
+  reattachMediaStream = function(to, from) {
+    to.src = from.src;
+  };
+
+  if (!navigator.mediaDevices) {
+    navigator.mediaDevices = {getUserMedia: requestUserMedia,
+                              enumerateDevices: function() {
+      return new Promise(function(resolve) {
+        var kinds = {audio: 'audioinput', video: 'videoinput'};
+        return MediaStreamTrack.getSources(function(devices) {
+          resolve(devices.map(function(device) {
+            return {label: device.label,
+                    kind: kinds[device.kind],
+                    deviceId: device.id,
+                    groupId: ''};
+          }));
+        });
+      });
+    }};
+    // in case someone wants to listen for the devicechange event.
+    navigator.mediaDevices.addEventListener = function() { };
+    navigator.mediaDevices.removeEventListener = function() { };
+  }
+} else if (navigator.mediaDevices && navigator.userAgent.match(
+    /Edge\/(\d+).(\d+)$/)) {
+  console.log('This appears to be Edge');
+  webrtcDetectedBrowser = 'edge';
+
+  webrtcDetectedVersion =
+    parseInt(navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)[2], 10);
+
+  // the minimum version still supported by adapter.
+  webrtcMinimumVersion = 12;
+
+  attachMediaStream = function(element, stream) {
+    element.srcObject = stream;
+  };
+  reattachMediaStream = function(to, from) {
+    to.srcObject = from.srcObject;
+  };
+} else {
+  console.log('Browser does not appear to be WebRTC-capable');
+}
+
+// Returns the result of getUserMedia as a Promise.
+function requestUserMedia(constraints) {
+  return new Promise(function(resolve, reject) {
+    getUserMedia(constraints, resolve, reject);
+  });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    RTCPeerConnection: RTCPeerConnection,
+    getUserMedia: getUserMedia,
+    attachMediaStream: attachMediaStream,
+    reattachMediaStream: reattachMediaStream,
+    webrtcDetectedBrowser: webrtcDetectedBrowser,
+    webrtcDetectedVersion: webrtcDetectedVersion,
+    webrtcMinimumVersion: webrtcMinimumVersion
+    //requestUserMedia: not exposed on purpose.
+    //trace: not exposed on purpose.
+  };
+} else if ((typeof require === 'function') && (typeof define === 'function')) {
+  // Expose objects and functions when RequireJS is doing the loading.
+  define([], function() {
+    return {
+      RTCPeerConnection: RTCPeerConnection,
+      getUserMedia: getUserMedia,
+      attachMediaStream: attachMediaStream,
+      reattachMediaStream: reattachMediaStream,
+      webrtcDetectedBrowser: webrtcDetectedBrowser,
+      webrtcDetectedVersion: webrtcDetectedVersion,
+      webrtcMinimumVersion: webrtcMinimumVersion
+      //requestUserMedia: not exposed on purpose.
+      //trace: not exposed on purpose.
+    };
+  });
+}

--- a/s/webrtc-simple-datachannel/index.html
+++ b/s/webrtc-simple-datachannel/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <title>WebRTC: Simple RTCDataChannel sample</title>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="main.css" type="text/css" media="all">
+  <script src="main.js"></script>
+</head>
+<body>
+  <h1>MDN - WebRTC: Simple RTCDataChannel sample</h1>
+  <p>This sample is an admittedly contrived example of how to use an RTCDataChannel to
+  exchange data between two objects on the same page. See the
+  <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample">
+  corresponding article</a> for details on how it works.</p>
+  
+  <label for="message">Enter a message:
+    <input type="text" name="message" id="message" placeholder="Message text">
+  </label>
+  <button id="sendButton" name="sendButton">Send</button>
+</body>
+</html

--- a/s/webrtc-simple-datachannel/index.html
+++ b/s/webrtc-simple-datachannel/index.html
@@ -4,6 +4,7 @@
   <title>WebRTC: Simple RTCDataChannel sample</title>
   <meta charset="utf-8">
   <link rel="stylesheet" href="main.css" type="text/css" media="all">
+  <script src="../adapter.js"></script>
   <script src="main.js"></script>
 </head>
 <body>
@@ -20,9 +21,13 @@
   
   <div class="messagebox">
     <label for="message">Enter a message:
-      <input type="text" name="message" id="message" placeholder="Message text">
+      <input type="text" name="message" id="message" placeholder="Message text" 
+              inputmode="latin" size=60 maxlength=120 disabled>
     </label>
     <button id="sendButton" name="sendButton" class="buttonright" disabled>Send</button>
+  </div>
+  <div class="messagebox" id="receivebox">
+    <p>Messages received:</p>
   </div>
 </body>
 </html

--- a/s/webrtc-simple-datachannel/index.html
+++ b/s/webrtc-simple-datachannel/index.html
@@ -13,9 +13,16 @@
   <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample">
   corresponding article</a> for details on how it works.</p>
   
-  <label for="message">Enter a message:
-    <input type="text" name="message" id="message" placeholder="Message text">
-  </label>
-  <button id="sendButton" name="sendButton">Send</button>
+  <div class="controlbox">
+    <button id="connectButton" name="connectButton" class="buttonleft">Connect</button>
+    <button id="disconnectButton" name="disconnectButton" class="buttonright" disabled>Disconnect</button>
+  </div>
+  
+  <div class="messagebox">
+    <label for="message">Enter a message:
+      <input type="text" name="message" id="message" placeholder="Message text">
+    </label>
+    <button id="sendButton" name="sendButton" class="buttonright" disabled>Send</button>
+  </div>
 </body>
 </html

--- a/s/webrtc-simple-datachannel/main.css
+++ b/s/webrtc-simple-datachannel/main.css
@@ -22,5 +22,3 @@ body {
   width: 450px;
   height: 28px;
 }
-
-.

--- a/s/webrtc-simple-datachannel/main.css
+++ b/s/webrtc-simple-datachannel/main.css
@@ -2,3 +2,25 @@ body {
   font-family: "Lucida Grande", "Arial", sans-serif;
   font-size: 16px;
 }
+
+.messagebox {
+  border: 1px solid black;
+  padding: 5px;
+  width: 450px;
+}
+
+.buttonright {
+  float: right;
+}
+
+.buttonleft {
+  float: left;
+}
+
+.controlbox {
+  padding: 5px;
+  width: 450px;
+  height: 28px;
+}
+
+.

--- a/s/webrtc-simple-datachannel/main.css
+++ b/s/webrtc-simple-datachannel/main.css
@@ -1,0 +1,4 @@
+body {
+  font-family: "Lucida Grande", "Arial", sans-serif;
+  font-size: 16px;
+}

--- a/s/webrtc-simple-datachannel/main.js
+++ b/s/webrtc-simple-datachannel/main.js
@@ -7,13 +7,27 @@
   // Set things up, connect event listeners, etc.
   
   function startup() {
+    var connectButton = document.getElementById('connectButton');
+    var disconnectButton = document.getElementById('disconnectButton');
     var sendButton = document.getElementById('sendButton');
     
+    // Set event listeners for user interface widgets
+    
+    connectButton.addEventListener('click', connectToPeer, false);
     sendButton.addEventListener('click', sendMessage, false);
   }
   
-  function sendMessage(e) {
-    console.log("Sending message: " + e);
+  // Connect to the remote peer.
+  
+  function connectToPeer() {
+    
+  }
+  
+  // Handles clicks on the "Send" button by transmitting
+  // a message to the remote peer.
+  
+  function sendMessage() {
+    console.log("Sending message");
   }
   
   // Set up an event listener which will run the startup

--- a/s/webrtc-simple-datachannel/main.js
+++ b/s/webrtc-simple-datachannel/main.js
@@ -1,0 +1,23 @@
+(function() {
+
+  // Define "global" variables
+  
+  // Functions
+  
+  // Set things up, connect event listeners, etc.
+  
+  function startup() {
+    var sendButton = document.getElementById('sendButton');
+    
+    sendButton.addEventListener('click', sendMessage, false);
+  }
+  
+  function sendMessage(e) {
+    console.log("Sending message: " + e);
+  }
+  
+  // Set up an event listener which will run the startup
+  // function once the page is done loading.
+  
+  window.addEventListener('load', startup, false);
+})();

--- a/s/webrtc-simple-datachannel/main.js
+++ b/s/webrtc-simple-datachannel/main.js
@@ -2,32 +2,229 @@
 
   // Define "global" variables
   
+  var connectButton = null;
+  var disconnectButton = null;
+  var sendButton = null;
+  var messageInputBox = null;
+  var receiveBox = null;
+  
+  var localConnection = null;   // RTCPeerConnection for our "local" connection
+  var remoteConnection = null;  // RTCPeerConnection for the "remote"
+  
+  var sendChannel = null;       // RTCDataChannel for the local (sender)
+  var receiveChannel = null;    // RTCDataChannel for the remote (receiver)
+  
   // Functions
   
   // Set things up, connect event listeners, etc.
   
   function startup() {
-    var connectButton = document.getElementById('connectButton');
-    var disconnectButton = document.getElementById('disconnectButton');
-    var sendButton = document.getElementById('sendButton');
+    connectButton = document.getElementById('connectButton');
+    disconnectButton = document.getElementById('disconnectButton');
+    sendButton = document.getElementById('sendButton');
+    messageInputBox = document.getElementById('message');
+    receiveBox = document.getElementById('receivebox');
     
     // Set event listeners for user interface widgets
     
-    connectButton.addEventListener('click', connectToPeer, false);
+    connectButton.addEventListener('click', connectPeers, false);
+    disconnectButton.addEventListener('click', disconnectPeers, false);
     sendButton.addEventListener('click', sendMessage, false);
   }
   
-  // Connect to the remote peer.
+  // Connect the two peers. Normally you look for and connect to a remote
+  // machine here, but we're just connecting two local objects, so we can
+  // bypass that step.
   
-  function connectToPeer() {
+  function connectPeers() {
+    // Create the local connection and its data channel
     
+    localConnection = new RTCPeerConnection();
+    sendChannel = localConnection.createDataChannel("sendChannel");
+    
+    // Set up local event listeners
+    
+    localConnection.onicecandidate = localICECallback;
+    sendChannel.onopen = handleSendChannelStatusChange;
+    sendChannel.onclose = handleSendChannelStatusChange;
+    
+    // Create the remote connection and its channel
+    
+    remoteConnection = new RTCPeerConnection();
+    
+    // Set up remote event listeners
+    
+    remoteConnection.onicecandidate = remoteICECallback;
+    remoteConnection.ondatachannel = receiveChannelCallback;
+    
+    // Now create an offer to connect
+    
+    localConnection.createOffer(gotLocalDescription,
+          handleCreateDescriptionError);
+    
+    // Update UI elements to reflect that the connection is in
+    // the process of opening
+    
+    connectButton.disabled = true;
+    disconnectButton.disabled = false;
   }
   
+  // Callback executed when the createOffer() request for the
+  // local connection is finished.
+  
+  function gotLocalDescription(theDescription) {
+    localConnection.setLocalDescription(theDescription);
+    
+    // Since we're also the remote machine, we're going to
+    // kick off the answer process here.
+    
+    remoteConnection.setRemoteDescription(theDescription);
+    remoteConnection.createAnswer(gotRemoteDescription,
+          handleCreateDescriptionError);
+  }
+  
+  // Handle ICE callbacks for the local connection.
+  
+  function localICECallback(event) {
+    if (event.candidate) {
+      remoteConnection.addIceCandidate(event.candidate, handleAddCandidateSuccess,
+              handleAddCandidateError);
+    }
+  }
+  
+  // Callback executed when the createAnswer() request for
+  // the remote connection finishes up.
+  
+  function gotRemoteDescription(theDescription) {
+    remoteConnection.setLocalDescription(theDescription);
+    localConnection.setRemoteDescription(theDescription);
+  }
+  
+  // Handle ICE callback for the remote connection.
+  
+  function remoteICECallback(event) {
+    if (event.candidate) {
+      localConnection.addIceCandidate(event.candidate,
+              handleAddCandidateSuccess, handleAddCandidateError);
+    }
+  }
+  
+  // Handle errors attempting to create a description;
+  // this can happen both when creating an offer and when
+  // creating an answer. In this simple example, we handle
+  // both the same way.
+  
+  function handleCreateDescriptionError(error) {
+    console.log("Unable to create an offer: " + error.toString());
+  }
+  
+  // Handle successful addition of ICE candidate.
+  
+  function handleAddCandidateSuccess() {
+    console.log("Yay! addICECandidate succeeded!");
+  }
+
+  // Handle an error that occurs during addition of ICE candidate.
+  
+  function handleAddCandidateError() {
+    console.log("Oh noes! addICECandidate failed!");
+  }
+
   // Handles clicks on the "Send" button by transmitting
   // a message to the remote peer.
   
   function sendMessage() {
-    console.log("Sending message");
+    var message = messageInputBox.value;
+    sendChannel.send(message);
+    
+    // Clear the input box and re-focus it, so that we're
+    // ready for the next message.
+    
+    messageInputBox.value = "";
+    messageInputBox.focus();
+  }
+  
+  // Handle status changes on the send channel.
+  
+  function handleSendChannelStatusChange() {
+    if (sendChannel) {
+      var state = sendChannel.readyState;
+    
+      if (sendChannel.readyState === "open") {
+        messageInputBox.disabled = false;
+        messageInputBox.focus();
+        sendButton.disabled = false;
+        disconnectButton.disabled = false;
+        connectButton.disabled = true;
+      } else {
+        messageInputBox.disabled = true;
+        sendButton.disabled = true;
+        connectButton.disabled = false;
+        disconnectButton.disabled = true;
+      }
+    }
+  }
+  
+  // Handle events that occur on the receiver's channel.
+  
+  function receiveChannelCallback(event) {
+    receiveChannel = event.channel;
+    receiveChannel.onmessage = handleReceiveMessage;
+    receiveChannel.onopen = handleReceiveChannelStatusChange;
+    receiveChannel.onclose = handleReceiveChannelStatusChange;
+  }
+  
+  // Handle onmessage events for the receiving channel.
+  // These are the data messages sent by the sending channel.
+  
+  function handleReceiveMessage(event) {
+    var el = document.createElement("p");
+    var txtNode = document.createTextNode(event.data);
+    
+    el.appendChild(txtNode);
+    receiveBox.appendChild(el);
+  }
+  
+  // Handle status changes on the receiver's channel.
+  
+  function handleReceiveChannelStatusChange() {
+    if (receiveChannel) {
+      console.log("Receive channel's status has changed to " +
+                  receiveChannel.readyState);
+    }
+    
+    // Here you would do stuff that needs to be done
+    // when the channel's status changes.
+  }
+  
+  // Close the connection, including data channels if they're open.
+  // Also update the UI to reflect the disconnected status.
+  
+  function disconnectPeers() {
+  
+    // Close the RTCDataChannels if they're open.
+    
+    sendChannel.close();
+    receiveChannel.close();
+    
+    // Close the RTCPeerConnections
+    
+    localConnection.close();
+    remoteConnection.close();
+
+    sendChannel = null;
+    receiveChannel = null;
+    localConnection = null;
+    remoteConnection = null;
+    
+    // Update user interface elements
+    
+    connectButton.disabled = false;
+    disconnectButton.disabled = true;
+    sendButton.disabled = true;
+    
+    messageInputBox.value = "";
+    messageInputBox.disabled = true;
   }
   
   // Set up an event listener which will run the startup

--- a/s/webrtc-simple-datachannel/manifest.json
+++ b/s/webrtc-simple-datachannel/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "WebRTC Simple RTCDataChannel sample",
+  "docsUrl": "https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample",
+  "description": "A simple example using a WebRTC data channel to signal between two objects on the same page."
+}


### PR DESCRIPTION
This adds the new webrtc-simple-datachannel sample; it's a very silly sample that uses WebRTC RTCDataChannels to send data from one element to another on the same page.
