### PR TITLE
Fix code license - should be CC0

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 	</p>
 </div>
 <div class="footer">
-	All content (including the sample code and the code for this support software is licensed under the <a href="http://creativecommons.org/licenses/by-sa/2.5/">CC-SA-BY</a> license, version 2.5 or later. 
+	All text content on this site and the code for this sample server is licensed under the <a href="http://creativecommons.org/licenses/by-sa/2.5/">CC-SA-BY</a> license, version 2.5 or later. The sample code itself is licensed under the <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 (Public Domain)</a> license and may be reused or repurposed without attribution.
 </div>
 </body>
 </html>


### PR DESCRIPTION
This fixes the footer on the main page of the site to correctly say that while text content and the code driving the site is under CC-BY-SA, the samples themselves are CC0 (Public Domain).
