### PR TITLE
Reliability fixes

### DIFF
--- a/s/webrtc-from-chat/chatclient.js
+++ b/s/webrtc-from-chat/chatclient.js
@@ -33,15 +33,6 @@ var myUsername = null;
 var targetUsername = null;  // To store username of other peer
 var myPeerConnection = null;    // RTCPeerConnection
 
-// Handle WebRTC prefixes.
-
-window.RTCPeerConnection = window.RTCPeerConnection || window.mozRTCPeerConnection || 
-                       window.webkitRTCPeerConnection || window.msRTCPeerConnection;
-window.RTCSessionDescription = window.RTCSessionDescription || window.mozRTCSessionDescription ||
-                       window.webkitRTCSessionDescription || window.msRTCSessionDescription;
-navigator.getUserMedia = navigator.getUserMedia || navigator.mozGetUserMedia ||
-                       navigator.webkitGetUserMedia || navigator.msGetUserMedia;
-
 // Called when the "id" message is received; this message is sent by the
 // server to assign this login session a unique ID number; in response,
 // this function sends a "username" message to set our username for this
@@ -292,8 +283,9 @@ function setupVideoCall(signalMessage) {
   // STUN server.
   
   myPeerConnection = new RTCPeerConnection({
-      "iceServers": [     // Information about ICE servers
+      iceServers: [     // Information about ICE servers
         { urls: "stun:" + stunServer }   // A STUN server
+//        { urls: "stun:52.5.80.241:3478" }
       ]
   });
 

--- a/s/webrtc-from-chat/index.html
+++ b/s/webrtc-from-chat/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <link href="chat.css" rel="stylesheet">
   <script type="text/javascript" src="chatclient.js"></script>
+  <script src="../adapter.js"></script>
 </head>
 <body>
   <p>This is a simple chat system implemented using WebSockets. It works by
@@ -29,7 +30,7 @@
       <div class="flexChild" id="camera-container">
         <div class="camera-box">
           <video id="received_video" autoplay></video>
-          <video id="local_video" autoplay></video>
+          <video id="local_video" autoplay muted></video>
           <button id="video-close" onclick="closeVideoCall(true);" disabled>Hang Up</button>
         </div>
       </div>


### PR DESCRIPTION
Pulled out custom prefixing code and switched to using adapter.js after
a discussion with jib and abr who strongly advise against manual
prefixing.

Added |muted| attribute to the local video box, to eliminate the crazy
sound problems.
