### PR TITLE
Simplify the startup process

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -26,16 +26,17 @@ def startService(path):
   if os.path.exists(startupScript):
     sys.stdout.flush()
     
-    pw_record = pwd.getpwnam("apache")
+#    pw_record = pwd.getpwnam("apache")
     
-    env = os.environ.copy()
-    env['HOME'] = pw_record.pw_dir
-    env['LOGNAME'] = pw_record.pw_name
-    env['PWD'] = path
-    env['USER'] = pw_record.pw_name
+#    env = os.environ.copy()
+#    env['HOME'] = pw_record.pw_dir
+#    env['LOGNAME'] = pw_record.pw_name
+#    env['PWD'] = path
+#    env['USER'] = pw_record.pw_name
     
     process = subprocess.Popen(
-      ["/bin/bash", startupScript], cwd = path, env = env, preexec_fn=demoteUser(pw_record.pw_uid, pw_record.pw_gid)
+#      ["/bin/bash", startupScript], cwd = path, env = env, preexec_fn=demoteUser(pw_record.pw_uid, pw_record.pw_gid)
+      ["/bin/bash", startupScript], cwd = path
     )
     
     # TODO: At some point we should record process IDs for restarts/shutdowns/etc

--- a/user-data.sh
+++ b/user-data.sh
@@ -3,11 +3,16 @@
 # This script is a once-per-instantiation script which is run the first time
 # the MDN sample server instance is started up.
 #
-# This lets us do things like ensure that specific software is installed,
-# as well as to spin-up needed background tasks.
+# Its job is to do the initial install of required software, make needed
+# changes to the main user account, clone the site contents into place as
+# a starting point, and install the script that should run at boot time.
+# That script runs on every server startup, including at instantiation (in
+# which case it happens after this instantiation-time script is complete).
 #
 # This script is based on this tutorial on the AWS docs site:
 #    http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-LAMP.html
+#
+# On AWS, this should be pasted into the "User data" field in Step 3.
 #
 # Any copyright is dedicated to the Public Domain.
 # http://creativecommons.org/publicdomain/zero/1.0/
@@ -28,17 +33,7 @@ usermod -a -G www ec2-user
 
 git clone https://github.com/mdn/samples-server /var/www/html
 
-# Pull the main startup scripts from github
+# Pull the main startup script from github
 
-curl https://raw.githubusercontent.com/mdn/samples-server/master/update.sh > /usr/local/bin/update.sh
-chmod +x /usr/local/bin/update.sh
-
-curl https://raw.githubusercontent.com/mdn/samples-server/master/startup.py > /var/lib/cloud/scripts/per-boot/startup.py
-chmod +x /var/lib/cloud/scripts/per-boot/startup.py
-
-# Create the service that will run the startup script on boot
-
-# Run the updater script; this will update the operating system and
-# system tools, then pull the latest code from Github
-
-/usr/local/bin/update.sh
+curl https://raw.githubusercontent.com/mdn/samples-server/master/update.sh > /var/lib/cloud/scripts/per-boot/update.sh
+chmod +x /var/lib/cloud/scripts/per-boot/update.sh


### PR DESCRIPTION
Simplify the startup process by:
1. Downloading update.sh to the per-boot folder instead of startup.py.
2. Remove code that specifically runs update.sh from user-data.sh,
   since it now gets run at boot per above.
3. Stop downloading update.sh to the bin folder since it’s not needed
   there anymore.
4. Disable code that downgrades the uid for services, since that was
   breaking startup.
