### PR TITLE
Run update first boot

### DIFF
--- a/user-data.sh
+++ b/user-data.sh
@@ -40,3 +40,7 @@ git clone https://github.com/mdn/samples-server /var/www/html
 
 curl https://raw.githubusercontent.com/mdn/samples-server/master/update.sh > /var/lib/cloud/scripts/per-boot/update.sh
 chmod +x /var/lib/cloud/scripts/per-boot/update.sh
+
+# Run the update script so it runs at instantiation time
+
+/var/lib/cloud/scripts/per-boot/update.sh


### PR DESCRIPTION
Looks like the update script doesn’t get run on first boot if it’s
installed during the first boot, so run it specifically.
