### PR TITLE
Fix bad variable names for hostname of server

### DIFF
--- a/s/webrtc-from-chat/chatclient.js
+++ b/s/webrtc-from-chat/chatclient.js
@@ -296,13 +296,13 @@ function setupVideoCall(signalMessage) {
   myPeerConnection = new RTCPeerConnection({
       iceServers: [     // Information about ICE servers - Use your own!
         {
-          urls: "stun:" + hostname   // A STUN server
+          urls: "stun:" + myHostname   // A STUN server
         },
         {
           urls: "stun:stun.l.google.com:19302"
         },
         {
-          urls: "turn:" + hostname,  // A TURN server
+          urls: "turn:" + myHostname,  // A TURN server
           username: "webrtc",
           credential: "turnserver"
         }


### PR DESCRIPTION
Accidentally forgot to commit this fix previously.
