### PR TITLE
Structural cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ docs/
 node_modules/
 
 *.js-bak
+.vscode

--- a/s/webrtc-from-chat/chat.css
+++ b/s/webrtc-from-chat/chat.css
@@ -1,14 +1,14 @@
 /*
     WebSocket chat client
-   
+
     WebSocket and WebRTC based multi-user chat sample with two-way video
     calling, including use of TURN if applicable or necessary.
-   
+
     This file describes the styling for the contents of the site as
     presented to users.
-   
+
     To read about how this sample works:  http://bit.ly/webrtc-from-chat
-   
+
     Any copyright is dedicated to the Public Domain.
     http:   creativecommons.org/publicdomain/zero/1.0/
 */
@@ -72,7 +72,7 @@
 }
 
 /* The "Hang up" button */
-#video-close {
+#hangup-button {
   display:block;
   width:80px;
   height:24px;
@@ -89,12 +89,12 @@
   cursor: pointer;
 }
 
-#video-close:hover {
+#hangup-button:hover {
   filter: brightness(150%);
   -webkit-filter: brightness(150%);
 }
 
-#video-close:disabled {
+#hangup-button:disabled {
   filter: grayscale(50%);
   -webkit-filter: grayscale(50%);
   cursor: default;

--- a/s/webrtc-from-chat/chatclient.js
+++ b/s/webrtc-from-chat/chatclient.js
@@ -40,7 +40,7 @@ var mediaConstraints = {
 };
 
 var myUsername = null;
-var targetUsername = null;  // To store username of other peer
+var targetUsername = null;      // To store username of other peer
 var myPeerConnection = null;    // RTCPeerConnection
 
 // Output logging information to console
@@ -114,26 +114,25 @@ function connect() {
           "</em> because the name you chose is in use.</b><br>";
         break;
       case "userlist":
-        var ul = "";
         var i;
-        
+  
         var listElem = document.getElementById("userlistbox");
-        
+  
         // Remove all current list members. We could do this smarter,
         // by adding and updating users instead of rebuilding from
         // scratch but this will do for this sample.
-        
+  
         while (listElem.firstChild) {
           listElem.removeChild(listElem.firstChild);
         }
-        
+  
         // Add member names from the received list
 
         for (i=0; i < msg.users.length; i++) {
           var item = document.createElement("li");
           item.appendChild(document.createTextNode(msg.users[i]));
           item.addEventListener("click", invite, false);
-          
+
           listElem.appendChild(item);
         }
         break;

--- a/s/webrtc-from-chat/chatclient.js
+++ b/s/webrtc-from-chat/chatclient.js
@@ -32,7 +32,7 @@ var clientID = 0;
 // See also:
 // https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamConstraints
 // https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
-// 
+//
 
 var mediaConstraints = {
   audio: true,            // We want an audio track
@@ -43,12 +43,20 @@ var myUsername = null;
 var targetUsername = null;      // To store username of other peer
 var myPeerConnection = null;    // RTCPeerConnection
 
-// Output logging information to console
+// Output logging information to console.
 
 function log(text) {
   var time = new Date();
-  
+
   console.log("[" + time.toLocaleTimeString() + "] " + text);
+}
+
+// Output an error message to console.
+
+function log_error(text) {
+  var time = new Date();
+
+  console.error("[" + time.toLocaleTimeString() + "] " + text);
 }
 
 // Send a JavaScript object by converting it to JSON and sending
@@ -56,7 +64,7 @@ function log(text) {
 
 function sendToServer(msg) {
   var msgJSON = JSON.stringify(msg);
-  
+
   log("Sending '" + msg.type + "' message: " + msgJSON);
   connection.send(msgJSON);
 }
@@ -79,17 +87,26 @@ function setUsername() {
 // Open and configure the connection to the WebSocket server.
 
 function connect() {
-  var serverUrl = "ws://" + myHostname + ":6503";
+  var serverUrl;
+  var scheme = "ws";
+
+  // If this is an HTTPS connection, we have to use a secure WebSocket
+  // connection too, so add another "s" to the scheme.
+
+  if (document.location.protocol === "https:") {
+    scheme += "s";
+  }
+  serverUrl = scheme + "://" + myHostname + ":6503";
 
   connection = new WebSocket(serverUrl, "json");
 
-  connection.onopen = function(evt) {
+  connection.onopen = function(event) {
     document.getElementById("text").disabled = false;
     document.getElementById("send").disabled = false;
   };
 
   connection.onmessage = function(evt) {
-    var f = document.getElementById("chatbox").contentDocument;
+    var chatFrameDocument = document.getElementById("chatbox").contentDocument;
     var text = "";
     var msg = JSON.parse(evt.data);
     log("Message received: ");
@@ -113,144 +130,40 @@ function connect() {
         text = "<b>Your username has been set to <em>" + myUsername +
           "</em> because the name you chose is in use.</b><br>";
         break;
-      case "userlist":
-        var i;
-  
-        var listElem = document.getElementById("userlistbox");
-  
-        // Remove all current list members. We could do this smarter,
-        // by adding and updating users instead of rebuilding from
-        // scratch but this will do for this sample.
-  
-        while (listElem.firstChild) {
-          listElem.removeChild(listElem.firstChild);
-        }
-  
-        // Add member names from the received list
+      case "userlist":      // Received an updated user list
+        handleUserlistMsg(msg);
+        break;
+      case "video-invite":  // Invited to a video call
+        handleVideoInviteMsg(msg);
+        break;
+      case "video-accept":  // Callee has accepted our request for video
+        handleVideoAcceptMsg(msg);
+        break;
 
-        for (i=0; i < msg.users.length; i++) {
-          var item = document.createElement("li");
-          item.appendChild(document.createTextNode(msg.users[i]));
-          item.addEventListener("click", invite, false);
+      // Signaling messages: these messages are used to trade WebRTC
+      // signaling information during negotiations leading up to a video
+      // call.
 
-          listElem.appendChild(item);
-        }
+      case "offer-or-answer": // An SDP offer or answer has arrived
+        handleOfferOrAnswerMsg(msg);
         break;
-      case "video-invite": // Invited to a video call
-        acceptInvite(msg);
+
+      case "new-ice-candidate": // A new ICE candidate has been received
+        handleNewICECandidateMsg(msg);
         break;
-    
-      // The other peer has accepted our request to begin a conversation,
-      // so we can now send an official offer.
-    
-      case "video-accept":
-        log("Call recipient has accepted request to negotiate");
-        
-        // Create an offer, set it as the description of our local media
-        // (which configures our local media stream), then send the
-        // description to the callee as an offer. This is a proposed media
-        // format, codec, resolution, etc.
-        
-        log("---> Creating offer");
-        myPeerConnection.createOffer().then(function(offer) {
-          log("---> Creating new description object to send to remote peer");
-          return myPeerConnection.setLocalDescription(offer);
-        })
-        .then(function() {
-          log("---> Sending description to remote peer");
-          sendToServer({
-            name: myUsername,
-            target: targetUsername,
-            type: "new-description",
-            sdp: myPeerConnection.localDescription
-          });
-        })
-        .catch(reportError);
-        break;
-      
-      // Signaling messages
-      
-      // A new SDP description has arrived, representing either an offer
-      // (sent by the caller) or an answer (sent by the callee).
-      case "new-description": {
-        log("Received SDP description from remote peer");
-        
-        var desc = new RTCSessionDescription(msg.sdp);
-      
-        log("--> SDP payload found of type: " + desc.type);
-        if (desc.type === "offer") {
-          log("----> It's an OFFER");
-          // Received an offer from the caller. We need to set the remote description
-          // to this SDP payload so that our local WebRTC layer knows how to talk to
-          // the caller.
-          myPeerConnection.setRemoteDescription(desc).then(function () {
-            log("------> Creating answer");
-            // Now that we've successfully set the remote description, we need to
-            // create an SDP answer; this SDP data describes the local end of our
-            // call, including the codec information, options agreed upon, and so
-            // forth.
-            return myPeerConnection.createAnswer();
-          })
-          .then(function(answer) {
-            log("------> Setting local description after creating answer");
-            // We now have our answer, so establish that as the local description.
-            // This actually configures our end of the call to match the settings
-            // specified in the SDP.
-            return myPeerConnection.setLocalDescription(answer);
-          })
-          .then(function() {
-            log("Sending answer packet back to other peer");
-            // We've configured our end of the call now. Time to send our
-            // answer back to the caller so they know we're set up. That
-            // should complete the process of starting up the call!
-            sendToServer({
-              name: myUsername,
-              target: targetUsername,
-              type: "new-description",
-              sdp: myPeerConnection.localDescription
-            });
-          })
-          .catch(reportError);
-        } else if (desc.type === "answer") {
-          log("----> It's an ANSWER");
-          // We've received an answer which has the details we need in
-          // order to exchange media with the other end, so configure
-          // ourselves to match. Now we're talking to the callee!
-          myPeerConnection.setRemoteDescription(desc).catch(reportError);
-        } else {
-          log("*** Unknown SDP payload type");
-        }
-        break;
-      }
-      
-      // A new ICE candidate has been received from the other peer. Call
-      // RTCPeerConnection.addIceCandidate() to send it along to the
-      // local ICE framework.
-      case "new-ice-candidate":
-        log("Received ICE candidate from remote peer: " + JSON.stringify(msg.candidate));
-        {
-          var candidate = new RTCIceCandidate(msg.candidate);
-          log("Adding candidate: " + JSON.stringify(candidate));
-          myPeerConnection.addIceCandidate(candidate)
-            .catch(reportError);
-        }
-        break;
-      
-      // The other end of the call has closed the call. Close our end, too.
-      
-      case "video-close":
-        closeVideoCall(false);
-        break;
-      
+
       // Unknown message; output to console for debugging.
-      
+
       default:
-        console.error("Unknown message received:");
-        console.error(msg);
+        log_error("Unknown message received:");
+        log_error(msg);
     }
 
+    // If there's text to insert into the chat buffer, do so now, then
+    // scroll the chat panel so that the new text is visible.
+
     if (text.length) {
-      f.write(text);
+      chatFrameDocument.write(text);
       document.getElementById("chatbox").contentWindow.scrollByPages(1);
     }
   };
@@ -289,10 +202,10 @@ function handleKey(evt) {
 
 function setupVideoCall(signalMessage) {
   log("Setting up a connection...");
-  
+
   // Create an RTCPeerConnection which knows to use our chosen
   // STUN server.
-  
+
   myPeerConnection = new RTCPeerConnection({
       iceServers: [     // Information about ICE servers - Use your own!
         {
@@ -308,12 +221,11 @@ function setupVideoCall(signalMessage) {
         }
       ]
   });
-  
+
   // Set up an |icecandidate| event handler which will forward
   // candiates created by our local ICE layer to the remote peer.
-  
+
   myPeerConnection.onicecandidate = function(event) {
-    log("*** icecandidate ***");
     if (event.candidate) {
       log("Outgoing ICE candidate: " + event.candidate.candidate);
 
@@ -327,14 +239,12 @@ function setupVideoCall(signalMessage) {
 
   // Set up a handler which is called when a stream starts coming in
   // from the callee.
-        
+
   myPeerConnection.onaddstream = function(event) {
-    log("*** addstream ***");
-    
     document.getElementById("received_video").srcObject = event.stream;
-    document.getElementById("video-close").disabled = false;
+    document.getElementById("hangup-button").disabled = false;
   };
-  
+
   // Set up a handler which is called when the remote end of the connection
   // removes its stream. We consider this the same as hanging up the call.
   // It could just as well be treated as a "mute".
@@ -342,31 +252,30 @@ function setupVideoCall(signalMessage) {
   // Note that currently, the spec is hazy on exactly when this and other
   // "connection failure" scenarios should occur, so sometimes they simply
   // don't happen.
-  
+
   myPeerConnection.onnremovestream = function(event) {
-    log("*** removestream ***");
-    closeVideoCall(true);
+    closeVideoCall();
   };
-  
+
   // Set up an ICE connection state change event handler. This will detect
   // when the ICE connection is closed, failed, or disconnected.
   //
   // Note that currently, the spec is hazy on exactly when this and other
   // "connection failure" scenarios should occur, so sometimes they simply
   // don't happen.
-  
+
   myPeerConnection.oniceconnectionstatechange = function(event) {
-    log("*** ICE connection state changing to " + myPeerConnection.iceConnectionState);
-    
+    log("*** ICE connection state changed to " + myPeerConnection.iceConnectionState);
+
     switch(myPeerConnection.iceConnectionState) {
       case "closed":
       case "failed":
       case "disconnected":
-        closeVideoCall(true);
+        closeVideoCall();
         break;
     }
   };
-  
+
   // Handle changes to the ICE gathering state. This lets us know what the
   // ICE engine is currently working on: "new" means no networking has happened
   // yet, "gathering" means the ICE engine is currently gathering candidates,
@@ -374,25 +283,25 @@ function setupVideoCall(signalMessage) {
   // alternate between "gathering" and "complete" repeatedly as needs and
   // circumstances change.
   myPeerConnection.onicegatheringstatechange = function(event) {
-    log("*** RECEIVED ICE GATHERING STATE CHANGE: " + myPeerConnection.iceGatheringState);
+    log("*** ICE gathering state changed to: " + myPeerConnection.iceGatheringState);
   };
-  
+
   // Set up a signaling state change event handler. This will detect when
   // the signaling connection is closed.
   //
   // Note that currently, the spec is hazy on exactly when this and other
   // "connection failure" scenarios should occur, so sometimes they simply
   // don't happen.
-  
+
   myPeerConnection.onsignalingstatechange = function(event) {
-    log("*** RECEIVED SIGNALING STATE CHANGE: " + myPeerConnection.signalingState);
+    log("*** WebRTC signaling state changed to: " + myPeerConnection.signalingState);
     switch(myPeerConnection.signalingState) {
       case "closed":
-        closeVideoCall(true);
+        closeVideoCall();
         break;
     }
   };
-                  
+
   // Start the process of connecting by requesting access to a
   // stream of audio and video from the local user's camera. This
   // returns a promise which when fulfilled provides the stream. At
@@ -404,10 +313,10 @@ function setupVideoCall(signalMessage) {
     log("Local video stream obtained");
     document.getElementById("local_video").src = window.URL.createObjectURL(localStream);
     document.getElementById("local_video").srcObject = localStream;
-    
+
     log("  -- Calling myPeerConnection.addStream()");
     myPeerConnection.addStream(localStream);
-    
+
     log("  -- Sending the signaling message now that gUM is done");
     sendToServer(signalMessage);
   })
@@ -431,66 +340,79 @@ function setupVideoCall(signalMessage) {
         break;
     }
   });
-};
+}
+
+// Given a message containing a list of usernames, this function
+// populates the user list box with those names, making each item
+// clickable to allow starting a video call.
+
+function handleUserlistMsg(msg) {
+  var i;
+
+  var listElem = document.getElementById("userlistbox");
+
+  // Remove all current list members. We could do this smarter,
+  // by adding and updating users instead of rebuilding from
+  // scratch but this will do for this sample.
+
+  while (listElem.firstChild) {
+    listElem.removeChild(listElem.firstChild);
+  }
+
+  // Add member names from the received list
+
+  for (i=0; i < msg.users.length; i++) {
+    var item = document.createElement("li");
+    item.appendChild(document.createTextNode(msg.users[i]));
+    item.addEventListener("click", invite, false);
+
+    listElem.appendChild(item);
+  }
+}
 
 // Close the RTCPeerConnection and reset variables so that the user can
 // make or receive another call if they wish. This is called both
 // when the user hangs up, the other user hangs up, or if a connection
 // failure is detected.
-//
-// If sendCloseMessage is true, we also send a "video-close" message to
-// the other peer so they know to hang up their end too. This is needed
-// since WebRTC is hazy on how to detect a terminated call.
 
-function closeVideoCall(sendCloseMessage) {
+function closeVideoCall() {
   var remoteVideo = document.getElementById("received_video");
   var localVideo = document.getElementById("local_video");
 
   log("Closing the call");
-  
+
   // Close the RTCPeerConnection
-  
+
   if (myPeerConnection) {
     log("--> Closing the peer connection");
 
     // Disconnect all our event listeners; we don't want stray events
     // to interfere with the hangup while it's ongoing.
-    
+
     myPeerConnection.onaddstream = null;
     myPeerConnection.onremovestream = null;
     myPeerConnection.onnicecandidate = null;
     myPeerConnection.oniceconnectionstatechange = null;
     myPeerConnection.onsignalingstatechange = null;
     myPeerConnection.onicegatheringstatechange = null;
-    
+
     // Stop the videos
-    
+
     remoteVideo.srcObject.getTracks().forEach(track => track.stop());
     localVideo.srcObject.getTracks().forEach(track => track.stop());
     remoteVideo.src = null;
     localVideo.src = null;
-    
+
     // Close the call
-    
+
     myPeerConnection.close();
     myPeerConnection = null;
   }
-  
+
   // Disable the hangup button
-  
-  document.getElementById("video-close").disabled = true;
-  
-  // If sendCloseMessage is true, ask the other end to hang up too.
-  /*
-  if (sendCloseMessage) {
-    log("--> Asking the other end to close too");
-    sendToServer({
-      name: myUsername,
-      target: targetUsername,
-      type: "video-close"
-    });
-  }
-*/
+
+  document.getElementById("hangup-button").disabled = true;
+
   targetUsername = null;
 }
 
@@ -503,24 +425,24 @@ function invite(evt) {
     alert("You can't start a call because you already have one open!");
   } else {
     var clickedUsername = evt.target.textContent;
-    
+
     // Don't allow users to call themselves, because weird.
-    
+
     if (clickedUsername === myUsername) {
       alert("I'm afraid I can't let you talk to yourself. That would be weird.");
       return;
     }
-    
+
     targetUsername = clickedUsername;
     log("Inviting user " + targetUsername);
-    
+
   // Call setupVideoCall() to create the RTCPeerConnection and to
   // use getUserMedia() to obtain our local stream so that we're ready
   // to share when the negotiations are complete. We provide a
   // "video-invite" message, which is sent to the callee via the
   // signaling server once getUserMedia() is fulfilled successfully;
   // this message invites the callee to start ICE negotiations.
-    
+
     log("Setting up connection to invite user: " + targetUsername);
     setupVideoCall({
       name: myUsername,
@@ -535,9 +457,9 @@ function invite(evt) {
 // saying that we're ready to begin negotiating the media format for
 // communication.
 
-function acceptInvite(msg) {
+function handleVideoInviteMsg(msg) {
   targetUsername = msg.name;
-  
+
   // Call setupVideoCall() to create the RTCPeerConnection and to
   // use getUserMedia() to obtain our local stream so that we're ready
   // to share when the negotiations are complete. We provide a
@@ -545,7 +467,7 @@ function acceptInvite(msg) {
   // signaling server once getUserMedia() has been successfully
   // fulfilled; this message tells the caller that we're ready to
   // negotiate the media format through an ICE exchange.
-  
+
   log("Starting to accept invitation from " + targetUsername);
   setupVideoCall({
     name: myUsername,
@@ -554,10 +476,100 @@ function acceptInvite(msg) {
   });
 }
 
+// Responds to the "video-accept" message sent by the callee once
+// it's decided to accept our request to talk by making a WebRTC offer.
+// We create the offer, set it as the description of our local media
+// (which configures our local media stream), then send the
+// description to the callee as an offer. This is a proposed media
+// format, codec, resolution, etc.
+
+function handleVideoAcceptMsg(msg) {
+  log("Call recipient has accepted request to negotiate");
+
+  log("---> Creating offer");
+  myPeerConnection.createOffer().then(function(offer) {
+    log("---> Creating new description object to send to remote peer");
+    return myPeerConnection.setLocalDescription(offer);
+  })
+  .then(function() {
+    log("---> Sending description to remote peer");
+    sendToServer({
+      name: myUsername,
+      target: targetUsername,
+      type: "offer-or-answer",
+      sdp: myPeerConnection.localDescription
+    });
+  })
+  .catch(reportError);
+}
+
+// The received message is either an SDP offer or an SDP answer,
+// describing a possible configuration for a WebRTC call.
+
+function handleOfferOrAnswerMsg(msg) {
+  log("Received SDP description from remote peer");
+
+  var desc = new RTCSessionDescription(msg.sdp);
+
+  log("--> SDP payload found of type: " + desc.type);
+  if (desc.type === "offer") {
+    // Received an offer from the caller. We need to set the remote description
+    // to this SDP payload so that our local WebRTC layer knows how to talk to
+    // the caller.
+    myPeerConnection.setRemoteDescription(desc).then(function () {
+      log("------> Creating answer");
+      // Now that we've successfully set the remote description, we need to
+      // create an SDP answer; this SDP data describes the local end of our
+      // call, including the codec information, options agreed upon, and so
+      // forth.
+      return myPeerConnection.createAnswer();
+    })
+    .then(function(answer) {
+      log("------> Setting local description after creating answer");
+      // We now have our answer, so establish that as the local description.
+      // This actually configures our end of the call to match the settings
+      // specified in the SDP.
+      return myPeerConnection.setLocalDescription(answer);
+    })
+    .then(function() {
+      log("Sending answer packet back to other peer");
+      // We've configured our end of the call now. Time to send our
+      // answer back to the caller so they know we're set up. That
+      // should complete the process of starting up the call!
+      sendToServer({
+        name: myUsername,
+        target: targetUsername,
+        type: "offer-or-answer",
+        sdp: myPeerConnection.localDescription
+      });
+    })
+    .catch(reportError);
+  } else if (desc.type === "answer") {
+    // We've received an answer which has the details we need in
+    // order to exchange media with the other end, so configure
+    // ourselves to match. Now we're talking to the callee!
+    myPeerConnection.setRemoteDescription(desc).catch(reportError);
+  } else {
+    log("*** Unknown SDP payload type");
+  }
+}
+
+// A new ICE candidate has been received from the other peer. Call
+// RTCPeerConnection.addIceCandidate() to send it along to the
+// local ICE framework.
+
+function handleNewICECandidateMsg(msg) {
+  var candidate = new RTCIceCandidate(msg.candidate);
+
+  log("Adding received ICE candidate: " + JSON.stringify(candidate));
+  myPeerConnection.addIceCandidate(candidate)
+    .catch(reportError);
+}
+
 // Handles reporting errors. Currently, we just dump stuff to console but
 // in a real-world application, an appropriate (and user-friendly)
 // error message should be displayed.
 
 function reportError(errMessage) {
-  console.error("***** Error " + errMessage.name + ": " + errMessage.message);
+  log_error("Error " + errMessage.name + ": " + errMessage.message);
 }

--- a/s/webrtc-from-chat/index.html
+++ b/s/webrtc-from-chat/index.html
@@ -48,7 +48,7 @@
         <div class="camera-box">
           <video id="received_video" autoplay></video>
           <video id="local_video" autoplay muted></video>
-          <button id="video-close" onclick="closeVideoCall(true);" disabled>
+          <button id="hangup-button" onclick="closeVideoCall(true);" disabled>
             Hang Up
           </button>
         </div>


### PR DESCRIPTION
Lots of improvements to code style. Also removed some stuff that’s not
needed and generally improved awesomeness.

Renamed some things to have more descriptive names (including element
IDs, messages, and variables).

Instead of calling console.error directly, now calls a new log_error()
function, which timestamps the same as the log() function.

Added code to automatically use wss:// instead of ws:// if the HTML is
loaded over HTTPS.

Took out the “video-close” message and its handler, since it wasn’t
being used anymore.

Moved most longish switch/case code out into functions to improve
readability when embedding pieces of code into articles.

Removed some unneeded logging.
