### PR TITLE
Add "()" to handleSendButton in onclick handler

### DIFF
--- a/s/webrtc-from-chat/index.html
+++ b/s/webrtc-from-chat/index.html
@@ -67,7 +67,7 @@
           placeholder="Chat with us!" autocomplete="off" onkeyup="handleKey(event)"
           disabled>
         <input type="button" id="send" name="send" value="Send"
-          onclick=handleSendButton disabled>
+          onclick="handleSendButton()" disabled>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The handleSendButton function isn't being called because of the missing parentheses.
