### PR TITLE
HTTPS tracks and streams

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -19,8 +19,6 @@
   "requireLineFeedAtFileEnd": true,
   "requireSemicolons": true,
   "requireSpaceAfterComma": true,
-  "requireSpaceAfterLineComment": true,
   "requireSpaceBeforeKeywords": true,
-  "validateIndentation": 2,
-  "validateQuoteMarks": { "mark": "\"", "escape": true }
+  "validateIndentation": 2
 }

--- a/s/webrtc-from-chat/README.md
+++ b/s/webrtc-from-chat/README.md
@@ -1,0 +1,6 @@
+WebRTC Video and Signaling sample
+=================================
+
+This sample demonstrates how to use WebSockets to create a signaling server for WebRTC calling. The signaling server is based on the WebSocket chat sample, but adds support for opening a video call to another user by clicking on their name in the user list sidebar.
+
+See the article [Signaling and video calling](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling) on MDN for detailed information on how this code works.

--- a/s/webrtc-from-chat/index.html
+++ b/s/webrtc-from-chat/index.html
@@ -22,7 +22,7 @@
   <link href="chat.css" rel="stylesheet">
   <link href="../shared.css" rel="stylesheet">
   <script type="text/javascript" src="chatclient.js"></script>
-  <script src="../adapter.js"></script>
+  <script src="adapter.js"></script>
 </head>
 <body>
   <p>This is a simple chat system implemented using WebSockets. It works by

--- a/s/webrtc-from-chat/package.json
+++ b/s/webrtc-from-chat/package.json
@@ -1,8 +1,21 @@
 {
   "name": "webrtc-from-chat",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "A simple WebSocket-based chat server with two-way video chat support added",
+  "homepage": "http://mdn-samples.mozilla.org/s/webrtc-from-chat/",
+  "bugs": "https://github.com/mdn/samples-server/issues",
+  "license": "CC0",
+  "author": "Eric Shepherd / Mozilla",
+  "main": "chatserver.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mdn/samples-server.git"
+  },
+  "scripts": {
+    "postinstall": "cp node_modules/webrtc-adapter/adapter.js ."
+  },
   "dependencies": {
-    "websocket": "*"
+    "websocket": "*",
+    "webrtc-adapter": "^1.1"
   }
 }


### PR DESCRIPTION
Support both the new track based API and the deprecated stream-based
one, since Chrome doesn’t do tracks yet (while Firefox has already
removed streams entirely).

Updated node manifest for video sample to get the webrtc-adapter module
and to copy the adapter.js file from it into the main directory for the
sample, then use that.

Added README.md for the video sample.
