### PR TITLE
Copy adapter.js from module to webrtc-from-chat directory

### DIFF
--- a/s/webrtc-from-chat/package.json
+++ b/s/webrtc-from-chat/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/mdn/samples-server.git"
   },
   "scripts": {
-    "postinstall": "cp node_modules/webrtc-adapter/adapter.js ."
+    "postinstall": "cp node_modules/webrtc-adapter/out/adapter.js ."
   },
   "dependencies": {
     "websocket": "*",

--- a/s/webrtc-from-chat/startup.sh
+++ b/s/webrtc-from-chat/startup.sh
@@ -13,4 +13,8 @@
 # http://creativecommons.org/publicdomain/zero/1.0/
 
 npm install websocket
+
+npm install webrtc-adapter
+cp node_modules/webrtc-adapter/out/adapter.js .
+
 node chatserver.js


### PR DESCRIPTION
Added postinstall and also startup.sh script code to copy adapter.js
from the npm module to the webrtc-from-chat directory. This is part of
an experiment to see if we can get better upgrade reliability using the
npm version of adapter.js.
