### PR TITLE
Fix bug 1275883

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,2 @@
+RedirectMatch 404 /\.git
+Options -Indexes

--- a/s/webrtc-from-chat/chatclient.js
+++ b/s/webrtc-from-chat/chatclient.js
@@ -531,7 +531,7 @@ function invite(evt) {
         log("-- Adding tracks to the RTCPeerConnection");
         localStream.getTracks().forEach(track => myPeerConnection.addTrack(track, localStream));
       } else {
-        log("-- Adding stream to the RTCPeerConnection")
+        log("-- Adding stream to the RTCPeerConnection");
         myPeerConnection.addStream(localStream);
       }
     })

--- a/user-data.sh
+++ b/user-data.sh
@@ -36,6 +36,11 @@ usermod -a -G www ec2-user
 
 git clone https://github.com/mdn/samples-server /var/www/html
 
+# Allow only root to access the .git directory - DISABLED
+# WHILE TRYING HTACCESS INSTEAD.
+
+# chmod og-rwx /var/www/html/.git
+
 # Pull the main startup script from github
 
 curl https://raw.githubusercontent.com/mdn/samples-server/master/update.sh > /var/lib/cloud/scripts/per-boot/update.sh


### PR DESCRIPTION
As a security precaution, don’t allow access to the .git\* directories;
these are now 404.
