### PR TITLE
navigator.getUserMedia -> navigator.mediaDevices.getUserMedia

### DIFF
--- a/s/webrtc-capturestill/capture.js
+++ b/s/webrtc-capturestill/capture.js
@@ -25,7 +25,8 @@
     photo = document.getElementById('photo');
     startbutton = document.getElementById('startbutton');
 
-    navigator.getMedia = ( navigator.getUserMedia ||
+    navigator.getMedia = ( navigator.mediaDevices.getUserMedia ||
+                           navigator.getUserMedia ||
                            navigator.webkitGetUserMedia ||
                            navigator.mozGetUserMedia ||
                            navigator.msGetUserMedia);


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia, we should advocate using `navigator.mediaDevices.getUserMedia` instead of `navigator.getUserMedia`.
