### PR TITLE
Updated to use navigator.mediaDevices.getUserMedia and srcObject.

### DIFF
--- a/s/webrtc-capturestill/capture.js
+++ b/s/webrtc-capturestill/capture.js
@@ -25,40 +25,18 @@
     photo = document.getElementById('photo');
     startbutton = document.getElementById('startbutton');
 
-    navigator.getMedia = ( navigator.getUserMedia ||
-                           navigator.webkitGetUserMedia ||
-                           navigator.mozGetUserMedia ||
-                           navigator.msGetUserMedia);
-
-    navigator.getMedia(
-      {
-        video: true,
-        audio: false
-      },
-      function(stream) {
-        if (navigator.mozGetUserMedia) {
-          video.mozSrcObject = stream;
-        } else {
-          var vendorURL = window.URL || window.webkitURL;
-          video.src = vendorURL.createObjectURL(stream);
-        }
+    navigator.mediaDevices.getUserMedia({ video: true,  audio: false })
+      .then(function(stream) {
+        video.srcObject = stream;
         video.play();
-      },
-      function(err) {
+      })
+      .catch(function(err) {
         console.log("An error occured! " + err);
-      }
-    );
+      });
 
     video.addEventListener('canplay', function(ev){
       if (!streaming) {
         height = video.videoHeight / (video.videoWidth/width);
-      
-        // Firefox currently has a bug where the height can't be read from
-        // the video, so we will make assumptions if this happens.
-      
-        if (isNaN(height)) {
-          height = width / (4/3);
-        }
       
         video.setAttribute('width', width);
         video.setAttribute('height', height);


### PR DESCRIPTION
Updated to avoid outdated patterns we're trying to deprecate.