### PR TITLE
Fix video display problem

### DIFF
--- a/s/webrtc-capturestill/capture.js
+++ b/s/webrtc-capturestill/capture.js
@@ -39,8 +39,7 @@
         if (navigator.mozGetUserMedia) {
           video.mozSrcObject = stream;
         } else {
-          var vendorURL = window.URL || window.webkitURL;
-          video.src = vendorURL.createObjectURL(stream);
+          video.src = stream;
         }
         video.play();
       },


### PR DESCRIPTION
For me the video didn't display in Safari 11, Firefox 60 & Chrome 67

This is fixed with this change