### PR TITLE
Use Node.js 10

### DIFF
--- a/user-data.sh
+++ b/user-data.sh
@@ -21,6 +21,7 @@
 # Install packages needed for Web server support
 
 yum groupinstall -y "Web Server" "PHP Support"
+curl -sL https://rpm.nodesource.com/setup_10.x | sudo bash -
 yum install -y nodejs
 yum install -y npm
 yum install -y openssl-devel


### PR DESCRIPTION
This switches from the default Node 6 to Node 10 for the base CentOS
install we're using for this instance at this time.