### PR TITLE
Remove extra double-quote character from chatbox iframe id attribute

### DIFF
--- a/s/websocket-chat/index.html
+++ b/s/websocket-chat/index.html
@@ -19,7 +19,7 @@
   <div id="userlistbox" style="border: 1px solid black; width:100%; height:100%;"></div>
   </td>
   <td>
-  <iframe width="100%" height="400px" id="chatbox""></iframe>
+  <iframe width="100%" height="400px" id="chatbox"></iframe>
   <tr>
   <td>&nbsp;</td>
   <td>


### PR DESCRIPTION
This repository is used in the [WebRTC - Signaling and Video Calling tutorial](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling#Updating_the_HTML). Working through this tutorial requires the reader to modify the document to add video related components. Upon doing so, my editor indicated a problem parsing the structure of the document due to the extra double-quote character in the `iframe#chatbox` element.