### PR TITLE
Updating CSP policy to include new domains

### DIFF
--- a/01-mdn-samples.conf
+++ b/01-mdn-samples.conf
@@ -25,9 +25,9 @@
 
     # HSTS (mod_headers is required) (15768000 seconds = 6 months)
     Header always set Strict-Transport-Security "max-age=15768000"
-    Header always append X-Frame-Options SAMEORIGIN
+    #Header always append X-Frame-Options SAMEORIGIN
     Header always set X-Content-Type-Options nosniff
-    Header always set Content-Security-Policy "frame-ancestors 'self';"
+    Header always set Content-Security-Policy "frame-ancestors 'self' *.mozilla.org *.allizom.org mdn.mozillademos.org;"
     Header always edit Set-Cookie (.*) "$1; HTTPOnly; Secure"
     Header always set X-Xss-Protection "1; mode=block"
     ServerSignature Off


### PR DESCRIPTION
Adding csp policy to include mozilla.org, allizom.org and mdn.mozillademos.org