### PR TITLE
Make capturestill work on mobile Safari

### DIFF
--- a/s/webrtc-capturestill/capture.js
+++ b/s/webrtc-capturestill/capture.js
@@ -28,6 +28,7 @@
     navigator.mediaDevices.getUserMedia({video: true, audio: false})
     .then(function(stream) {
       video.srcObject = stream;
+      video.setAttribute("playsinline", true);
       video.play();
     })
     .catch(function(err) {


### PR DESCRIPTION
Set playsinline attribute of video to true to make WebRTC work on mobile Safari.
Solution found [here](https://github.com/webrtc/samples/issues/929).
fixes #94 